### PR TITLE
Add 'dev' profile via a deftask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+tags
+.nrepl*

--- a/autoeval.clj
+++ b/autoeval.clj
@@ -1,25 +1,30 @@
-(ns autoeval)
+(ns autoeval
+  (:require [prc :as prc]))
 
 ;; This file demonstrates the autoeval functionality.
 ;; All top level forms will be immediately evaluated.
 
-;; Turn on autoeval by bringing up the command palette and selecting Proto Repl: Autoeval File
+;; Turn on autoeval by bringing up the command palette
+;; and selecting Proto Repl: Autoeval File
 
 ;; Uncomment this line. It should be immediately evaluated
-; (+ 2 3)
+(comment
+ (+ 2 3))
 
 ;; Uncomment me
-; (for [n (range 10)]
-;   (* 2 n))
+(comment
+ (for [n (range 10)]
+   (* 2 n)))
 
 ;; Proto REPL Charts work as well if you have it installed.
 ;; See https://github.com/jasongilman/proto-repl-charts
 
 ;; Uncomment me
-; (prc/line-chart
-;  "Trigonometry"
-;  {"sin" (map #(Math/sin %) (range 0.0 6.0 0.2))
-;   "cos" (map #(Math/cos %) (range 0.0 6.0 0.2))})
+(comment
+ (prc/line-chart
+  "Trigonometry"
+  {"sin" (map #(Math/sin %) (range 0.0 6.0 0.2))
+   "cos" (map #(Math/cos %) (range 0.0 6.0 0.2))}))
 
 ;; Turn off Autoeval by bringing up the command palette and selecting:
 ;; Proto Repl: Stop Autoeval File

--- a/build.boot
+++ b/build.boot
@@ -1,8 +1,17 @@
 (set-env!
-	:source-paths #{"dev" "src" "test"}
+	:source-paths #{"src"}
 	:dependencies '[[org.clojure/clojure "1.8.0"]
                  [proto-repl "0.1.2"]
-                 [proto-repl-charts "0.1.0"]
-							   [org.clojure/tools.namespace "0.2.11"]])
+                 [proto-repl-charts "0.1.0"]])
 
 (println "welcome to boot")
+
+(deftask dev
+	"Profile setup for development.
+	Starting the repl with the dev profile...
+	boot dev repl "
+	[]
+	(set-env!
+		:source-paths #(into % ["dev" "test"])
+		:dependencies #(conj % '[org.clojure/tools.namespace "0.2.11"]))
+	identity)

--- a/build.boot
+++ b/build.boot
@@ -1,0 +1,8 @@
+(set-env!
+	:source-paths #{"dev" "src" "test"}
+	:dependencies '[[org.clojure/clojure "1.8.0"]
+                 [proto-repl "0.1.2"]
+                 [proto-repl-charts "0.1.0"]
+							   [org.clojure/tools.namespace "0.2.11"]])
+
+(println "welcome to boot")


### PR DESCRIPTION
Boot does not have profiles per se. 
The way it is done is via 'deftask' the task is then inserted into the task stream.
  boot --no-color dev repl

This means that the build.boot file should be updated to have the dev task.
That is what this change does.
This needs to be done intentionally by the developer so 
documentation should emphasize the point.

The default arguments in proto-repl should be modified to provide this additional argument.
Look for that separate pull request.
Note also that this is related to issue #5
